### PR TITLE
Changed the way admin shows related table names in row details so it can use translations

### DIFF
--- a/modules/content/templates/relations/default/index.php
+++ b/modules/content/templates/relations/default/index.php
@@ -12,7 +12,7 @@ defined('ANS') or die();
 
 <div class="format">
     <label class="field f20">
-        <strong><?php echo $info['title']; ?></strong>
+        <strong><?php echo $Content->info($Vars->get('connection'), 'name', $info['table']); ?></strong>
     </label>
 
     <div class="f80">


### PR DESCRIPTION
Use the content info method to get table name instead os using the
title so it can use translations.
